### PR TITLE
#165 Revamped model overwriting and added new prints

### DIFF
--- a/prometheus_driving/scripts/model_train.py
+++ b/prometheus_driving/scripts/model_train.py
@@ -77,6 +77,7 @@ def main():
 
     print(f'{Fore.BLUE}The dataset has {len(df)} images{Style.RESET_ALL}')
 
+    model_name = args["folder_name"]
     model_path = files_path + f'/models/{args["folder_name"]}/{args["folder_name"]}.pkl'
     folder_path =files_path + f'/models/{args["folder_name"]}'
     # Checks if the models folder exists if not create
@@ -107,7 +108,7 @@ def main():
     # Creates the batch size that suits the amount of memory the graphics can handle
     loader_train = torch.utils.data.DataLoader(dataset=dataset_train,batch_size=args['batch_size'],shuffle=True,num_workers=args['num_workers'])
     # Creates the test dataset
-    dataset_test = Dataset(test_dataset,dataset_path)
+    dataset_test = Dataset(test_dataset , dataset_path , augmentation=False)
     # Creates the batch size that suits the amount of memory the graphics can handle
     loader_test = torch.utils.data.DataLoader(dataset=dataset_test, batch_size=args['batch_size'], shuffle=True)
 
@@ -227,7 +228,7 @@ def main():
             print(Fore.CYAN + 'Finished training. Reached maximum number of epochs. Comparing to previously stored model' + Style.RESET_ALL)
             if epoch_train_loss < stored_train_loss:
                 print(Fore.BLUE + 'Saving model at Epoch ' + str(idx_epoch) + ' Loss ' + str(epoch_train_loss) + Style.RESET_ALL)
-                SaveModel(model,idx_epoch,optimizer,loader_train,loader_test,epoch_train_losses,epoch_test_losses,folder_path,device,args['model_name'],args['model'],idx_epoch,args['batch_size'],train_losses[-1],test_losses[-1],args['loss_function'],data_loaded) # Saves the model
+                SaveModel(model,idx_epoch,optimizer,loader_train,loader_test,epoch_train_losses,epoch_test_losses,folder_path,device,model_name,args['model'],idx_epoch,args['batch_size'],train_losses[-1],test_losses[-1],args['loss_function'],data_loaded) # Saves the model
                 SaveGraph(epoch_train_losses,epoch_test_losses,folder_path)
             else:
                 print(Fore.BLUE + 'Not saved, current loos '+ str(epoch_train_loss) + '. Previous model is better, previous loss ' + str(stored_train_loss) + '.' + Style.RESET_ALL)
@@ -236,7 +237,7 @@ def main():
             print(Fore.CYAN + 'Finished training. Reached target loss. Comparing to previously stored model' + Style.RESET_ALL)
             if epoch_train_loss < stored_train_loss:
                 print(Fore.BLUE + 'Saving model at Epoch ' + str(idx_epoch) + ' Loss ' + str(epoch_train_loss) + Style.RESET_ALL)
-                SaveModel(model,idx_epoch,optimizer,loader_train,loader_test,epoch_train_losses,epoch_test_losses,folder_path,device,args['model_name'],args['model'],idx_epoch,args['batch_size'],train_losses[-1],test_losses[-1],args['loss_function'],data_loaded) # Saves the model
+                SaveModel(model,idx_epoch,optimizer,loader_train,loader_test,epoch_train_losses,epoch_test_losses,folder_path,device,model_name,args['model'],idx_epoch,args['batch_size'],train_losses[-1],test_losses[-1],args['loss_function'],data_loaded) # Saves the model
                 SaveGraph(epoch_train_losses,epoch_test_losses,folder_path)
             else:
                 print(Fore.BLUE + 'Not saved, current loos '+ str(epoch_train_loss) + '. Previous model is better, previous loss ' + str(stored_train_loss) + '.' + Style.RESET_ALL)
@@ -250,7 +251,7 @@ def main():
             if epoch_train_loss < stored_train_loss: # checks if the previous model is better than the new one
                 print(Fore.BLUE + 'Saving model at Epoch ' + str(idx_epoch) + ' Loss ' + str(epoch_train_loss) + Style.RESET_ALL)
                 # Save checkpoint
-                SaveModel(model,idx_epoch,optimizer,loader_train,loader_test,epoch_train_losses,epoch_test_losses,folder_path,device,args['model_name'],args['model'],idx_epoch,args['batch_size'],train_losses[-1],test_losses[-1],args['loss_function'],data_loaded) # Saves the model
+                SaveModel(model,idx_epoch,optimizer,loader_train,loader_test,epoch_train_losses,epoch_test_losses,folder_path,device,model_name,args['model'],idx_epoch,args['batch_size'],train_losses[-1],test_losses[-1],args['loss_function'],data_loaded) # Saves the model
                 SaveGraph(epoch_train_losses,epoch_test_losses,folder_path)
                 stored_train_loss=epoch_train_loss
                 


### PR DESCRIPTION
Some changes were done to the script to ease training.

Firstly, I assumed there only existed one model per folder. Therefore, the model_name arg parse does not make sense and it can be removed because I used the folder_name as the model_name.

Secondly, I revamped the start of training, because it did not contemplated the situation I had experienced.
Imagine you have an empty model folder, because you canceled the training before the model is saved.
You would need to erase the folder manually to reuse it again.
With this new method, it does that automatically.
I also added the option to overwrite the current model.

Thirdly, I added two new arguments:

- num_workers - which defines how many subprocesses to use for data loading. 0 means that the data will be loaded in the main process
- prefetch_factor - number of batches loaded in advance by each worker

I request that @andrefdre reviews this. This is your work and if anything I did does not align with your vision, feel free to alter or to remove this PR.